### PR TITLE
Bump required provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Currently, the `encrypt at transit` is not supported in terraform. There is an o
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, <= 1.5.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.38 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 
 ## Providers
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,8 +19,8 @@ provider "random" {}
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, <= 1.5.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.38 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -16,11 +16,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0"
+      version = "~> 5.38"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.6.0"
+      version = "~> 3.6"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -16,11 +16,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.32.0"
+      version = "~> 5.38"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.6.0"
+      version = "~> 3.6"
     }
   }
 


### PR DESCRIPTION
Sets minimum AWS provider version to 5.38 (where `execution_mode` was added).